### PR TITLE
license: change license from GPL-3.0 to MIT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.6.1"
 description = "Inquirer based on Textual"
 authors = [{ name = "Rob van der Leek", email = "robvanderleek@gmail.com" }]
 readme = "README.md"
-license = "GPL-3.0-or-later"
+license = "MIT"
 requires-python = ">=3.9,<3.15"
 
 dependencies = [


### PR DESCRIPTION
Correct errors in the metadata. The repo and the package are licensed under the MIT license

